### PR TITLE
lib: set privileged bit on pinger

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -204,6 +204,7 @@ func (c *Client) CheckConnection(timeout time.Duration, cancelCtx context.Contex
 		return false
 	}
 
+	pinger.SetPrivileged(true)
 	pinger.Timeout = timeout
 	pinger.Count = 3
 	pinger.Interval = 10 * time.Millisecond // Send approximately all at once


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets privileged bit on pinger in `CheckConnection()` in `client.go` to allow ICMP packet sending.
> 
>   - **Behavior**:
>     - Sets `pinger.SetPrivileged(true)` in `CheckConnection()` in `client.go` to allow sending ICMP packets.
>   - **Misc**:
>     - No other changes made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fvprox&utm_source=github&utm_medium=referral)<sup> for 3b3bdf3c3028d3b3beec38f10248c99cf661dee4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->