### PR TITLE
*: add a region flag to vprox and fix some internal network interface…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Build
+        run: CGO_ENABLED=0 go build

--- a/lib/iputils.go
+++ b/lib/iputils.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"net/netip"
+	"strings"
 	"sync"
 
 	"github.com/vishvananda/netlink"
@@ -40,6 +41,99 @@ func getDefaultInterface() (netlink.Link, error) {
 	}
 
 	return nil, fmt.Errorf("failed to find default route")
+}
+
+func getInternalInterface() (netlink.Link, error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list interfaces: %v", err)
+	}
+
+	// Define interface types to skip
+	skipTypes := map[string]bool{
+		"veth":      true,
+		"bridge":    true,
+		"dummy":     true,
+		"wireguard": true,
+		"docker":    true,
+	}
+
+	var candidates []netlink.Link
+	for _, link := range links {
+		// Skip interfaces that aren't up
+		if link.Attrs().OperState != netlink.OperUp {
+			continue
+		}
+
+		// Skip certain interface types
+		if skipTypes[link.Type()] {
+			continue
+		}
+
+		// Skip interfaces with certain name patterns
+		name := link.Attrs().Name
+		if strings.HasPrefix(name, "veth") ||
+			strings.HasPrefix(name, "docker") ||
+			strings.HasPrefix(name, "wg") {
+			continue
+		}
+
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		if err != nil {
+			log.Printf("failed to get addresses for interface %s: %v", name, err)
+			continue
+		}
+
+		// Check for RFC1918 addresses
+		for _, addr := range addrs {
+			if isRFC1918(addr.IP) {
+				candidates = append(candidates, link)
+				break
+			}
+		}
+	}
+
+	// If we found candidates, prefer physical interfaces over others
+	for _, link := range candidates {
+		name := link.Attrs().Name
+		// Common patterns for physical interfaces
+		if strings.HasPrefix(name, "en") ||
+			strings.HasPrefix(name, "eth") ||
+			strings.HasPrefix(name, "enp") ||
+			strings.HasPrefix(name, "ens") {
+			return link, nil
+		}
+	}
+
+	// If no physical interface found, return the first candidate
+	if len(candidates) > 0 {
+		return candidates[0], nil
+	}
+
+	return nil, fmt.Errorf("failed to find internal interface")
+}
+
+// Helper function to check if an interface is a VLAN interface
+func isVLANInterface(link netlink.Link) bool {
+	_, isVlan := link.(*netlink.Vlan)
+	if !isVlan {
+		// Also check the name for "@" which indicates a VLAN interface in Linux
+		return strings.Contains(link.Attrs().Name, ".")
+	}
+	return true
+}
+
+// Helper function to check RFC1918 addresses
+func isRFC1918(ip net.IP) bool {
+	if ip4 := ip.To4(); ip4 != nil {
+		// Convert to 32-bit integer for easier comparison
+		ipInt := uint32(ip4[0])<<24 | uint32(ip4[1])<<16 | uint32(ip4[2])<<8 | uint32(ip4[3])
+
+		return (ipInt >= 0x0A000000 && ipInt <= 0x0AFFFFFF) || // 10.0.0.0/8
+			(ipInt >= 0xAC100000 && ipInt <= 0xAC1FFFFF) || // 172.16.0.0/12
+			(ipInt >= 0xC0A80000 && ipInt <= 0xC0A8FFFF) // 192.168.0.0/16
+	}
+	return false
 }
 
 // IpAllocator is a simple IP address allocator that produces IP addresses

--- a/lib/server.go
+++ b/lib/server.go
@@ -57,6 +57,12 @@ type Server struct {
 	// Currently only setting this to the default interface is supported.
 	BindIface netlink.Link
 
+	// InternalBindIface is the interface for internal network traffic.
+	InternalBindIface netlink.Link
+
+	// InternalNetworkCidr is the CIDR block of the internal network.
+	InternalNetworkCidr string
+
 	// Password is needed to authenticate connection requests.
 	Password string
 
@@ -75,6 +81,9 @@ type Server struct {
 	// Ctx is the shutdown context for the server.
 	Ctx context.Context
 
+	// Region is the region of the server.
+	Region string
+
 	ipAllocator *IpAllocator
 
 	mu       sync.Mutex // Protects the fields below.
@@ -89,6 +98,13 @@ func (srv *Server) InitState() error {
 			return err
 		}
 		srv.BindIface = iface
+	}
+	if srv.Region == "us-west" && srv.InternalBindIface == nil {
+		iface, err := getInternalInterface()
+		if err != nil {
+			return err
+		}
+		srv.InternalBindIface = iface
 	}
 
 	srv.ipAllocator = NewIpAllocator(srv.WgCidr)
@@ -332,43 +348,45 @@ func (srv *Server) StartIptables() error {
 		return fmt.Errorf("failed to add inbound TCP MSS rule: %v", err)
 	}
 
-	// SNAT rule for internal network traffic
-	// TODO(adityamaru): Make the source and the -o interface dynamic and not hardcoded.
-	rule = []string{
-		"-s", "10.100.0.0/16",
-		"-d", "10.0.0.0/24",
-		"-o", "bond0.2",
-		"-j", "SNAT", "--to-source", "10.0.0.40",
-		"-m", "comment", "--comment", "SNAT for WireGuard to internal network",
-	}
-	if err := srv.Ipt.AppendUnique("nat", "POSTROUTING", rule...); err != nil {
-		return fmt.Errorf("failed to add SNAT rule: %v", err)
-	}
+	// SNAT rule for internal network traffic. This is currently only applicable for boxes in
+	// the US.
+	if srv.Region == "us-west" {
+		rule = []string{
+			"-s", srv.WgCidr.String(),
+			"-d", srv.InternalNetworkCidr,
+			"-o", srv.InternalBindIface.Attrs().Name,
+			"-j", "SNAT", "--to-source", srv.BindAddr.String(),
+			"-m", "comment", "--comment", "SNAT for WireGuard to internal network",
+		}
+		if err := srv.Ipt.AppendUnique("nat", "POSTROUTING", rule...); err != nil {
+			return fmt.Errorf("failed to add SNAT rule: %v", err)
+		}
 
-	// FORWARD rule from WireGuard to internal network
-	rule = []string{
-		"-i", srv.Ifname(),
-		"-o", "bond0.2",
-		"-s", "10.100.0.0/16",
-		"-d", "10.0.0.0/24",
-		"-j", "ACCEPT",
-		"-m", "comment", "--comment", "Forward from WireGuard to internal network",
-	}
-	if err := srv.Ipt.AppendUnique("filter", "FORWARD", rule...); err != nil {
-		return fmt.Errorf("failed to add FORWARD rule: %v", err)
-	}
+		// FORWARD rule from WireGuard to internal network
+		rule = []string{
+			"-i", srv.Ifname(),
+			"-o", srv.InternalBindIface.Attrs().Name,
+			"-s", srv.WgCidr.String(),
+			"-d", srv.InternalNetworkCidr,
+			"-j", "ACCEPT",
+			"-m", "comment", "--comment", "Forward from WireGuard to internal network",
+		}
+		if err := srv.Ipt.AppendUnique("filter", "FORWARD", rule...); err != nil {
+			return fmt.Errorf("failed to add FORWARD rule: %v", err)
+		}
 
-	// FORWARD rule from internal network to WireGuard
-	rule = []string{
-		"-i", "bond0.2",
-		"-o", srv.Ifname(),
-		"-s", "10.0.0.0/24",
-		"-d", "10.100.0.0/16",
-		"-j", "ACCEPT",
-		"-m", "comment", "--comment", "Forward from internal network to WireGuard",
-	}
-	if err := srv.Ipt.AppendUnique("filter", "FORWARD", rule...); err != nil {
-		return fmt.Errorf("failed to add FORWARD rule: %v", err)
+		// FORWARD rule from internal network to WireGuard
+		rule = []string{
+			"-i", srv.InternalBindIface.Attrs().Name,
+			"-o", srv.Ifname(),
+			"-s", srv.InternalNetworkCidr,
+			"-d", srv.WgCidr.String(),
+			"-j", "ACCEPT",
+			"-m", "comment", "--comment", "Forward from internal network to WireGuard",
+		}
+		if err := srv.Ipt.AppendUnique("filter", "FORWARD", rule...); err != nil {
+			return fmt.Errorf("failed to add FORWARD rule: %v", err)
+		}
 	}
 
 	return nil
@@ -420,43 +438,44 @@ func (srv *Server) CleanupIptables() {
 		log.Printf("failed to remove inbound TCP MSS rule: %v", err)
 	}
 
-	// Remove SNAT rule for internal traffic
-	rule = []string{
-		"-s", srv.WgCidr.String(),
-		"-d", "10.0.0.0/24",
-		"-o", srv.BindIface.Attrs().Name,
-		"-j", "SNAT",
-		"--to-source", srv.BindAddr.String(),
-		"-m", "comment", "--comment", fmt.Sprintf("vprox SNAT rule for internal traffic from %s", srv.Ifname()),
-	}
-	if err := srv.Ipt.Delete("nat", "POSTROUTING", rule...); err != nil {
-		log.Printf("failed to remove SNAT rule for internal traffic: %v", err)
-	}
+	if srv.Region == "us-west" {
+		// Remove SNAT rule for internal traffic
+		rule = []string{
+			"-s", srv.WgCidr.String(),
+			"-d", srv.InternalNetworkCidr,
+			"-o", srv.InternalBindIface.Attrs().Name,
+			"-j", "SNAT", "--to-source", srv.BindAddr.String(),
+			"-m", "comment", "--comment", "SNAT for WireGuard to internal network",
+		}
+		if err := srv.Ipt.Delete("nat", "POSTROUTING", rule...); err != nil {
+			log.Printf("failed to remove SNAT rule for internal traffic: %v", err)
+		}
 
-	// Remove forward rule from WireGuard to internal network
-	rule = []string{
-		"-i", srv.Ifname(),
-		"-o", srv.BindIface.Attrs().Name,
-		"-s", srv.WgCidr.String(),
-		"-d", "10.0.0.0/24",
-		"-j", "ACCEPT",
-		"-m", "comment", "--comment", fmt.Sprintf("vprox forward rule from %s to internal network", srv.Ifname()),
-	}
-	if err := srv.Ipt.Delete("filter", "FORWARD", rule...); err != nil {
-		log.Printf("failed to remove forward rule from WireGuard to internal network: %v", err)
-	}
+		// Remove forward rule from WireGuard to internal network
+		rule = []string{
+			"-i", srv.Ifname(),
+			"-o", srv.InternalBindIface.Attrs().Name,
+			"-s", srv.WgCidr.String(),
+			"-d", srv.InternalNetworkCidr,
+			"-j", "ACCEPT",
+			"-m", "comment", "--comment", "Forward from WireGuard to internal network",
+		}
+		if err := srv.Ipt.Delete("filter", "FORWARD", rule...); err != nil {
+			log.Printf("failed to remove forward rule from WireGuard to internal network: %v", err)
+		}
 
-	// Remove forward rule from internal network to WireGuard
-	rule = []string{
-		"-i", srv.BindIface.Attrs().Name,
-		"-o", srv.Ifname(),
-		"-s", "10.0.0.0/24",
-		"-d", srv.WgCidr.String(),
-		"-j", "ACCEPT",
-		"-m", "comment", "--comment", fmt.Sprintf("vprox forward rule from internal network to %s", srv.Ifname()),
-	}
-	if err := srv.Ipt.Delete("filter", "FORWARD", rule...); err != nil {
-		log.Printf("failed to remove forward rule from internal network to WireGuard: %v", err)
+		// Remove forward rule from internal network to WireGuard
+		rule = []string{
+			"-i", srv.InternalBindIface.Attrs().Name,
+			"-o", srv.Ifname(),
+			"-s", srv.InternalNetworkCidr,
+			"-d", srv.WgCidr.String(),
+			"-j", "ACCEPT",
+			"-m", "comment", "--comment", "Forward from internal network to WireGuard",
+		}
+		if err := srv.Ipt.Delete("filter", "FORWARD", rule...); err != nil {
+			log.Printf("failed to remove forward rule from internal network to WireGuard: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
… resolution
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `region` flag to `vprox` server, modify internal network interface resolution, and update iptables rules for `us-west` region.
> 
>   - **Behavior**:
>     - Add `--region` flag to `serverCmdArgs` in `cmd/server.go`, making it a required parameter.
>     - Remove AWS-specific IP polling logic from `cmd/server.go`.
>     - Modify `runServer()` to pass `region` to `NewServerManager()`.
>   - **Network Interface**:
>     - Add `getInternalInterface()` in `lib/iputils.go` to resolve internal network interfaces.
>     - Use `getInternalInterface()` in `Server.InitState()` in `lib/server.go` for `us-west` region.
>   - **Iptables**:
>     - Add SNAT and FORWARD iptables rules for internal traffic in `Server.StartIptables()` in `lib/server.go` for `us-west` region.
>     - Remove these rules in `Server.CleanupIptables()`.
>   - **Server Management**:
>     - Update `NewServerManager()` in `lib/server_manager.go` to accept `region` parameter.
>     - Pass `region` to `Server` instances in `ServerManager.Start()`.
>   - **CI/CD**:
>     - Add new GitHub Actions workflow `build.yaml` for building the project.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fvprox&utm_source=github&utm_medium=referral)<sup> for 0b08cb9927d6e35cad8b562f6ef39efa7297e764. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->