### PR TITLE
cmd: add liveness reporter to ping our backend

### DIFF
--- a/cmd/liveness_reporter.go
+++ b/cmd/liveness_reporter.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+type LivenessReporter struct {
+	client            http.Client
+	backendEndpoint   string
+	backendAdminToken string
+	ip                string
+	region            string
+}
+
+func (r *LivenessReporter) Report(ctx context.Context) {
+	requestBody := struct {
+		IP     string `json:"ip"`
+		Region string `json:"region"`
+	}{
+		IP:     r.ip,
+		Region: r.region,
+	}
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		fmt.Printf("failed to marshal request body: %v\n", err)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/staticip/liveness", r.backendEndpoint), bytes.NewBuffer(jsonBody))
+	if err != nil {
+		fmt.Printf("failed to create request: %v\n", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", r.backendAdminToken))
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		fmt.Printf("failed to send request: %v\n", err)
+		return
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("failed to close response body: %v\n", err)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		fmt.Printf("error reporting liveness: unexpected status code: %d\n", resp.StatusCode)
+	}
+}
+
+const (
+	minLivenessReportInterval = 1500 * time.Millisecond
+	maxLivenessReportInterval = 2 * time.Second
+)
+
+func (r *LivenessReporter) Start(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(r.randomInterval())
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				r.Report(ctx)
+				ticker.Reset(r.randomInterval())
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (r *LivenessReporter) randomInterval() time.Duration {
+	return time.Duration(rand.Int63n(int64(maxLivenessReportInterval-minLivenessReportInterval))) + minLivenessReportInterval
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `LivenessReporter` to report server liveness to backend, integrated into server startup in `server.go`.
> 
>   - **Liveness Reporter**:
>     - Add `LivenessReporter` struct in `liveness_reporter.go` to report server liveness.
>     - `Report()` sends HTTP POST to backend with IP and region, handles request errors.
>     - `Start()` initiates periodic reporting with random interval between 1500ms and 2000ms.
>     - `randomInterval()` calculates random reporting interval.
>   - **Server Integration**:
>     - In `server.go`, initialize `LivenessReporter` in `runServer()` with IP, region, and backend credentials.
>     - Call `LivenessReporter.Start()` to begin liveness reporting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fvprox&utm_source=github&utm_medium=referral)<sup> for e2c626bb8a8b9eb7f496efd1123d58db066c050f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->